### PR TITLE
feat: created websocket provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "tsnodemon": "^1.2.2",
     "ws": "^7.4.6",
     "y-codemirror": "^2.1.1",
+    "y-protocols": "^1.0.5",
     "y-webrtc": "^10.2.0",
     "y-websocket": "^1.3.15",
     "yjs": "^13.5.10"

--- a/src/socket-message-handling.ts
+++ b/src/socket-message-handling.ts
@@ -1,9 +1,13 @@
+import { decoding, encoding } from "lib0";
 import * as map from "lib0/map";
+import * as awarenessProtocol from "y-protocols/awareness";
+import * as syncProtocol from "y-protocols/sync";
+import { getYDoc } from "./utils/ws-shared-doc";
 
 const wsReadyStateConnecting = 0;
 const wsReadyStateOpen = 1;
-const wsReadyStateClosing = 2; // eslint-disable-line
-const wsReadyStateClosed = 3; // eslint-disable-line
+const messageSync = 0;
+const messageAwareness = 1;
 
 /**
  * Map froms topic-name to set of subscribed clients.
@@ -25,7 +29,7 @@ const send = (conn, message) => {
     conn.close();
   }
   try {
-    conn.send(JSON.stringify(message));
+    conn.send(message);
   } catch (e) {
     conn.close();
   }
@@ -35,12 +39,22 @@ const send = (conn, message) => {
  * Setup a new client
  * @param {any} conn
  */
-const setupWSConnection = (conn) => {
+const setupWSConnection = (
+  conn,
+  req,
+  { docName = req.url.slice(1).split("?")[0], gc = true } = {}
+) => {
+
   /**
    * @type {Set<string>}
    */
   const subscribedTopics = new Set();
+
   let closed = false;
+
+  const doc = getYDoc(docName, gc);
+  doc.conns.set(conn, new Set());
+
   // Check if connection is still alive
   let pongReceived = true;
   const pingInterval = setInterval(() => {
@@ -76,52 +90,100 @@ const setupWSConnection = (conn) => {
   conn.on(
     "message",
     /** @param {object} message */ (message) => {
-      if (typeof message === "string") {
-        message = JSON.parse(message);
-      }
-      if (message && message.type && !closed) {
-        switch (message.type) {
-          case "subscribe":
-            /** @type {Array<string>} */ (message.topics || []).forEach(
-              (topicName) => {
-                if (typeof topicName === "string") {
-                  // add conn to topic
-                  const topic = map.setIfUndefined(
-                    topics,
-                    topicName,
-                    () => new Set()
-                  );
-                  topic.add(conn);
-                  // add topic to conn
-                  subscribedTopics.add(topicName);
-                }
+      if (message && !closed) {
+        if (Buffer.isBuffer(message)) {
+          message = new Uint8Array(message);
+          const encoder = encoding.createEncoder();
+          const decoder = decoding.createDecoder(message);
+          const messageType = decoding.readVarUint(decoder);
+          switch (messageType) {
+            case messageSync:
+              encoding.writeVarUint(encoder, messageSync);
+              syncProtocol.readSyncMessage(decoder, encoder, doc, null);
+              if (encoding.length(encoder) > 1) {
+                doc.send(conn, encoding.toUint8Array(encoder));
               }
-            );
-            break;
-          case "unsubscribe":
-            /** @type {Array<string>} */ (message.topics || []).forEach(
-              (topicName) => {
-                const subs = topics.get(topicName);
-                if (subs) {
-                  subs.delete(conn);
-                }
-              }
-            );
-            break;
-          case "publish":
-            if (message.topic) {
-              const receivers = topics.get(message.topic);
-              if (receivers) {
-                receivers.forEach((receiver) => send(receiver, message));
-              }
+              // TODO:
+              // doc is now the updated document
+              // we need to figure out how to persist this
+              break;
+            case messageAwareness: {
+              awarenessProtocol.applyAwarenessUpdate(
+                doc.awareness,
+                decoding.readVarUint8Array(decoder),
+                conn
+              );
+              break;
             }
-            break;
-          case "ping":
-            send(conn, { type: "pong" });
+          };
+        } else if (message.type) {
+          message = JSON.parse(message);
+          switch (message.type) {
+            case "subscribe":
+              /** @type {Array<string>} */ (message.topics || []).forEach(
+                (topicName) => {
+                  if (typeof topicName === "string") {
+                    // add conn to topic
+                    const topic = map.setIfUndefined(
+                      topics,
+                      topicName,
+                      () => new Set()
+                    );
+                    topic.add(conn);
+                    // add topic to conn
+                    subscribedTopics.add(topicName);
+                  }
+                }
+              );
+              break;
+            case "unsubscribe":
+              /** @type {Array<string>} */ (message.topics || []).forEach(
+                (topicName) => {
+                  const subs = topics.get(topicName);
+                  if (subs) {
+                    subs.delete(conn);
+                  }
+                }
+              );
+              break;
+            case "publish":
+              if (message.topic) {
+                const receivers = topics.get(message.topic);
+                if (receivers) {
+                  receivers.forEach((receiver) =>
+                    send(receiver, JSON.stringify(message))
+                  );
+                }
+              }
+              break;
+            case "ping":
+              send(conn, JSON.stringify({ type: "pong" }));
+          };
         }
       }
     }
   );
+
+  {
+    // send sync step 1
+    const encoder = encoding.createEncoder();
+    encoding.writeVarUint(encoder, messageSync);
+    syncProtocol.writeSyncStep1(encoder, doc);
+    doc.send(conn, encoding.toUint8Array(encoder));
+    const awarenessStates = doc.awareness.getStates();
+    if (awarenessStates.size > 0) {
+      const encoder = encoding.createEncoder();
+      encoding.writeVarUint(encoder, messageAwareness);
+      encoding.writeVarUint8Array(
+        encoder,
+        awarenessProtocol.encodeAwarenessUpdate(
+          doc.awareness,
+          Array.from(awarenessStates.keys())
+        )
+      );
+      doc.send(conn, encoding.toUint8Array(encoder));
+    }
+  }
 };
 
 export default setupWSConnection;

--- a/src/utils/ws-shared-doc.ts
+++ b/src/utils/ws-shared-doc.ts
@@ -1,0 +1,114 @@
+import { encoding, mutex } from "lib0";
+import * as Y from "yjs";
+import * as awarenessProtocol from "y-protocols/awareness";
+import * as map from "lib0/map";
+
+const messageAwareness = 1;
+const wsReadyStateConnecting = 0;
+const wsReadyStateOpen = 1;
+
+// We keep a set of documents in memory here.
+const docs = new Map<string,WSSharedDoc>();
+
+export const getYDoc = (docname, gc = true): WSSharedDoc =>
+  map.setIfUndefined(docs, docname, () => {
+    const doc = new WSSharedDoc(docname);
+    doc.gc = gc;
+    docs.set(docname, doc);
+    return doc;
+  });
+
+export class WSSharedDoc extends Y.Doc {
+  name: string;
+  mux: any;
+  conns: Map<any, any>;
+  awareness: any;
+  /**
+   * @param {string} name
+   */
+  constructor(name) {
+    super();
+    this.name = name;
+    this.mux = mutex.createMutex();
+
+    /**
+     * Maps from conn to set of controlled user ids. Delete all user ids from awareness when this conn is closed
+     * @type {Map<Object, Set<number>>}
+     */
+    this.conns = new Map();
+
+    /**
+     * @type {awarenessProtocol.Awareness}
+     */
+    this.awareness = new awarenessProtocol.Awareness(this);
+    this.awareness.setLocalState(null);
+
+    /**
+     * @param {{ added: Array<number>, updated: Array<number>, removed: Array<number> }} changes
+     * @param {Object | null} conn Origin is the connection that made the change
+     */
+    const awarenessChangeHandler = ({ added, updated, removed }, conn) => {
+      const changedClients = added.concat(updated, removed);
+      if (conn !== null) {
+        const connControlledIDs =
+          /** @type {Set<number>} */ this.conns.get(conn);
+        if (connControlledIDs !== undefined) {
+          added.forEach((clientID) => {
+            connControlledIDs.add(clientID);
+          });
+          removed.forEach((clientID) => {
+            connControlledIDs.delete(clientID);
+          });
+        }
+      }
+      // broadcast awareness update
+      const encoder = encoding.createEncoder();
+      encoding.writeVarUint(encoder, messageAwareness);
+      encoding.writeVarUint8Array(
+        encoder,
+        awarenessProtocol.encodeAwarenessUpdate(this.awareness, changedClients)
+      );
+      const buff = encoding.toUint8Array(encoder);
+      this.conns.forEach((_, c) => {
+        this.send(c, buff);
+      });
+    };
+    this.awareness.on("update", awarenessChangeHandler);
+  }
+
+  send(conn, buff) {
+    if (
+      conn.readyState !== wsReadyStateConnecting &&
+      conn.readyState !== wsReadyStateOpen
+    ) {
+      this._closeConn(conn);
+    }
+    try {
+      conn.send(buff, (err) => {
+        err != null && this._closeConn(conn);
+      });
+    } catch (e) {
+      this._closeConn(conn);
+    }
+  }
+
+  _closeConn(conn) {
+    if (this.conns.has(conn)) {
+      /**
+       * @type {Set<number>}
+       */
+      // @ts-ignore
+      const controlledIds = this.conns.get(conn);
+      this.conns.delete(conn);
+      awarenessProtocol.removeAwarenessStates(
+        this.awareness,
+        Array.from(controlledIds),
+        null
+      );
+      if (this.conns.size === 0) {
+        docs.delete(this.name);
+      }
+    }
+    conn.close();
+  }
+}


### PR DESCRIPTION
Description

1.  Implements shared doc awareness update service
2. Factored out two separate message resolvers for the two services [signaling, provider]

Below shows the network interaction of the client editor & the awareness update service on the backend. 'down' arrows (received messages) are logged on one client (image shown) when updating the document from a different client.

<img width="356" alt="Screen Shot 2021-07-06 at 5 12 06 PM" src="https://user-images.githubusercontent.com/53843009/124667778-df167000-de7d-11eb-88c4-b42a3e46572f.png">


