### PR TITLE
[chore] remove nojekyll test from workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,7 +22,6 @@ jobs:
         node-version: 14.x
     - run: yarn
     - run: yarn build
-    - run: touch dist/webpage/.nojekyll
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@4.1.4
       with:


### PR DESCRIPTION
Description:

1. Migrating from github pages to GCP makes the test for the nojekyll dotfile obsolete, so it is removed.