### PR TITLE
[chore] give document_updates_queue a default time

### DIFF
--- a/packages/service/db/migrations/20210722161826_add_timestamp_field_to_documents.sql
+++ b/packages/service/db/migrations/20210722161826_add_timestamp_field_to_documents.sql
@@ -1,4 +1,5 @@
 -- migrate:up
+DELETE from document; 
 ALTER TABLE document ADD latest_update_time timestamp NOT NULL;
 -- migrate:down
 ALTER TABLE document DROP COLUMN latest_update_time;

--- a/packages/service/db/migrations/20210722181845_update-created-at.sql
+++ b/packages/service/db/migrations/20210722181845_update-created-at.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+ALTER TABLE document_updates_queue ADD created_at timestamp DEFAULT now() NOT NULL;
+ALTER TABLE document_updates_queue DROP update_time;
+
+-- migrate:down
+ALTER TABLE document_updates_queue DROP created_at;
+ALTER TABLE document_updates_queue ADD update_time ADD timestamp DEFAULT now() NOT NULL;

--- a/packages/service/db/schema.sql
+++ b/packages/service/db/schema.sql
@@ -48,7 +48,7 @@ CREATE TABLE public.document_updates_queue (
     id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
     document_id uuid NOT NULL,
     document_update bytea NOT NULL,
-    update_time timestamp without time zone NOT NULL
+    created_at timestamp without time zone DEFAULT now() NOT NULL
 );
 
 
@@ -168,4 +168,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20210713211341'),
     ('20210715214346'),
     ('20210720160437'),
-    ('20210722161826');
+    ('20210722161826'),
+    ('20210722181845');


### PR DESCRIPTION
This will assign a created_at time when the row is inserted.
This field should never have to be writen too manually.