### PR TITLE
[feat] implement naming scheme for documents

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   proxy:
-    image: nginx
+    image: nginx:1.21.1
     volumes:
       - ./terraform/nginx:/etc/nginx/templates
     depends_on:

--- a/packages/client/src/components/create-document.tsx
+++ b/packages/client/src/components/create-document.tsx
@@ -15,18 +15,23 @@ export default function CreateDocument() {
   const me = useSelector(selectUser);
   const [postDocument, { isLoading: postLoading }] = usePostDocumentMutation();
   const { refetch } = useGetDocumentsQuery();
+  const name = "whatever";
+  // const updateName = (event) => {
+  //   setName(event.target.value)
+  // }
 
   const handleCreate = async (e) => {
     e.preventDefault();
-    await postDocument();
+    await postDocument({name});
     await refetch();
   };
 
   return (
-    <Form onSubmit={(e) => handleCreate(e)}>
+    <Form onSubmit={handleCreate}>
       <h2>
-        {me ? "create a new document" : "log in to create a new document"}
+        {me ? "Create a new document" : "Log in to create a new document"}
       </h2>
+      <label>Document Name</label> <input name="name" type="text" value="whatever"/>
       <button type={"submit"} disabled={postLoading || !me}>
         submit
       </button>

--- a/packages/client/src/ducks/api.ts
+++ b/packages/client/src/ducks/api.ts
@@ -5,10 +5,11 @@ export const api = createApi({
   reducerPath: "api",
   baseQuery: fetchBaseQuery({ baseUrl: "/api" }),
   endpoints: (builder) => ({
-    postDocument: builder.mutation<UserDocument, void>({
-      query: () => ({
+    postDocument: builder.mutation<UserDocument, Partial<UserDocument>>({
+      query: ({name}) => ({
         url: "/document",
         method: "POST",
+        body: name,
       }),
       transformResponse: (response: { document: UserDocument }) =>
         response.document,

--- a/packages/client/src/ducks/types.ts
+++ b/packages/client/src/ducks/types.ts
@@ -6,4 +6,5 @@ export type User = {
 export type UserDocument = {
   id: string;
   creator_id: string;
+  name: string;
 };

--- a/packages/client/src/pages/index.tsx
+++ b/packages/client/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import Me from "components/me";
+import CreateDocument from "components/create-document";
 import DocumentSelect from "components/select-document";
 import React from "react";
 import dynamic from "next/dynamic";
@@ -18,6 +19,7 @@ export default function Index() {
       <a href="/login">Login</a>
       <a href="/create-user">Create Account</a>
       <a href="/update-password">Update Password</a>
+      <CreateDocument />
       <DocumentSelect />
       <Editor />
     </PageLayout>

--- a/packages/service/db/migrations/20210812163559_add-name-column-documents.sql
+++ b/packages/service/db/migrations/20210812163559_add-name-column-documents.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+ALTER TABLE document ADD name text DEFAULT '' NOT NULL;
+
+-- migrate:down
+ALTER TABLE document DROP name;

--- a/packages/service/db/schema.sql
+++ b/packages/service/db/schema.sql
@@ -51,7 +51,8 @@ CREATE TABLE public.document (
     web_rtc_key text NOT NULL,
     origin bytea NOT NULL,
     latest_update_time timestamp without time zone NOT NULL,
-    creator_id uuid NOT NULL
+    creator_id uuid NOT NULL,
+    name text DEFAULT ''::text NOT NULL
 );
 
 
@@ -204,4 +205,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20210722181845'),
     ('20210723153150'),
     ('20210726125556'),
-    ('20210729151156');
+    ('20210729151156'),
+    ('20210812163559');

--- a/packages/service/src/service.ts
+++ b/packages/service/src/service.ts
@@ -64,7 +64,7 @@ app.use(passport.session());
 
 app.post("/login", passport.authenticate("local", { successRedirect: "/" }));
 
-app.post("/user/update-password", async function (req, resp, next) {
+app.post("/user/update-password", async function (req, resp) {
   const result = await updatePassword(req.body);
   if (!result) {
     resp.send(401);
@@ -90,7 +90,8 @@ app.get("/users", auth, async function (resp) {
   }
 });
 app.post("/document", auth, async function (req, resp) {
-  const dbDoc = await createDocument({ doc: new Y.Doc(), user: req.user });
+  console.log("Made it to server: ", req.body);
+  const dbDoc = await createDocument({ new_doc: new Y.Doc(), doc: req.document, user: req.user });
   resp.send({
     user: req.user,
     document: dbDoc,

--- a/packages/service/src/utils/documents.ts
+++ b/packages/service/src/utils/documents.ts
@@ -13,19 +13,22 @@ export function insertUpdate(document_id: string, document_update: Uint8Array) {
 }
 
 export const createDocument = ({
+  new_doc,
   doc,
   user,
 }: {
-  doc: Y.Doc;
+  new_doc: Y.Doc;
+  doc: { name: string };
   user: { id: string };
 }) =>
   db
     .insert("document", {
-      value: doc.getText(TEXT_NAME).toJSON(),
-      origin: Buffer.from(Y.encodeStateAsUpdate(doc)),
+      value: new_doc.getText(TEXT_NAME).toJSON(),
+      origin: Buffer.from(Y.encodeStateAsUpdate(new_doc)),
       web_rtc_key: "",
       creator_id: user.id,
       latest_update_time: new Date(),
+      name: doc.name,
     })
     .run(pool);
 

--- a/packages/service/src/zapatos/schema.d.ts
+++ b/packages/service/src/zapatos/schema.d.ts
@@ -7,17 +7,17 @@ Copyright (C) 2020 - 2021 George MacKerron
 Released under the MIT licence: see LICENCE file
 */
 
-declare module "zapatos/schema" {
-  import type * as db from "zapatos/db";
+declare module 'zapatos/schema' {
+
+  import type * as db from 'zapatos/db';
 
   // got a type error on schemaVersionCanary below? update by running `npx zapatos`
-  export interface schemaVersionCanary extends db.SchemaVersionCanary {
-    version: 103;
-  }
+  export interface schemaVersionCanary extends db.SchemaVersionCanary { version: 103 }
 
   /* === schema: public === */
 
   /* --- enums --- */
+
 
   /* --- tables --- */
 
@@ -26,308 +26,231 @@ declare module "zapatos/schema" {
    * - Table in database
    */
   export namespace document {
-    export type Table = "document";
+    export type Table = 'document';
     export interface Selectable {
       /**
-       * **document.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
+      * **document.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
       id: string;
       /**
-       * **document.value**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
+      * **document.value**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
       value: string;
       /**
-       * **document.web_rtc_key**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
+      * **document.web_rtc_key**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
       web_rtc_key: string;
       /**
-       * **document.origin**
-       * - `bytea` in database
-       * - `NOT NULL`, no default
-       */
+      * **document.origin**
+      * - `bytea` in database
+      * - `NOT NULL`, no default
+      */
       origin: Buffer;
       /**
-       * **document.latest_update_time**
-       * - `timestamp` in database
-       * - `NOT NULL`, no default
-       */
+      * **document.latest_update_time**
+      * - `timestamp` in database
+      * - `NOT NULL`, no default
+      */
       latest_update_time: Date;
       /**
-       * **document.creator_id**
-       * - `uuid` in database
-       * - `NOT NULL`, no default
-       */
+      * **document.creator_id**
+      * - `uuid` in database
+      * - `NOT NULL`, no default
+      */
       creator_id: string;
+      /**
+      * **document.name**
+      * - `text` in database
+      * - `NOT NULL`, default: `''::text`
+      */
+      name: string;
     }
     export interface JSONSelectable {
       /**
-       * **document.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
+      * **document.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
       id: string;
       /**
-       * **document.value**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
+      * **document.value**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
       value: string;
       /**
-       * **document.web_rtc_key**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
+      * **document.web_rtc_key**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
       web_rtc_key: string;
       /**
-       * **document.origin**
-       * - `bytea` in database
-       * - `NOT NULL`, no default
-       */
+      * **document.origin**
+      * - `bytea` in database
+      * - `NOT NULL`, no default
+      */
       origin: db.ByteArrayString;
       /**
-       * **document.latest_update_time**
-       * - `timestamp` in database
-       * - `NOT NULL`, no default
-       */
+      * **document.latest_update_time**
+      * - `timestamp` in database
+      * - `NOT NULL`, no default
+      */
       latest_update_time: db.TimestampString;
       /**
-       * **document.creator_id**
-       * - `uuid` in database
-       * - `NOT NULL`, no default
-       */
+      * **document.creator_id**
+      * - `uuid` in database
+      * - `NOT NULL`, no default
+      */
       creator_id: string;
+      /**
+      * **document.name**
+      * - `text` in database
+      * - `NOT NULL`, default: `''::text`
+      */
+      name: string;
     }
     export interface Whereable {
       /**
-       * **document.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
-      id?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
-          >;
+      * **document.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
+      id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
       /**
-       * **document.value**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
-      value?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
-          >;
+      * **document.value**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      value?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
       /**
-       * **document.web_rtc_key**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
-      web_rtc_key?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
-          >;
+      * **document.web_rtc_key**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      web_rtc_key?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
       /**
-       * **document.origin**
-       * - `bytea` in database
-       * - `NOT NULL`, no default
-       */
-      origin?:
-        | (db.ByteArrayString | Buffer)
-        | db.Parameter<db.ByteArrayString | Buffer>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            | (db.ByteArrayString | Buffer)
-            | db.Parameter<db.ByteArrayString | Buffer>
-            | db.SQLFragment
-            | db.ParentColumn
-          >;
+      * **document.origin**
+      * - `bytea` in database
+      * - `NOT NULL`, no default
+      */
+      origin?: (db.ByteArrayString | Buffer) | db.Parameter<(db.ByteArrayString | Buffer)> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, (db.ByteArrayString | Buffer) | db.Parameter<(db.ByteArrayString | Buffer)> | db.SQLFragment | db.ParentColumn>;
       /**
-       * **document.latest_update_time**
-       * - `timestamp` in database
-       * - `NOT NULL`, no default
-       */
-      latest_update_time?:
-        | (db.TimestampString | Date)
-        | db.Parameter<db.TimestampString | Date>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            | (db.TimestampString | Date)
-            | db.Parameter<db.TimestampString | Date>
-            | db.SQLFragment
-            | db.ParentColumn
-          >;
+      * **document.latest_update_time**
+      * - `timestamp` in database
+      * - `NOT NULL`, no default
+      */
+      latest_update_time?: (db.TimestampString | Date) | db.Parameter<(db.TimestampString | Date)> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, (db.TimestampString | Date) | db.Parameter<(db.TimestampString | Date)> | db.SQLFragment | db.ParentColumn>;
       /**
-       * **document.creator_id**
-       * - `uuid` in database
-       * - `NOT NULL`, no default
-       */
-      creator_id?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
-          >;
+      * **document.creator_id**
+      * - `uuid` in database
+      * - `NOT NULL`, no default
+      */
+      creator_id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
+      /**
+      * **document.name**
+      * - `text` in database
+      * - `NOT NULL`, default: `''::text`
+      */
+      name?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
     }
     export interface Insertable {
       /**
-       * **document.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
+      * **document.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
       id?: string | db.Parameter<string> | db.DefaultType | db.SQLFragment;
       /**
-       * **document.value**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
+      * **document.value**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
       value: string | db.Parameter<string> | db.SQLFragment;
       /**
-       * **document.web_rtc_key**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
+      * **document.web_rtc_key**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
       web_rtc_key: string | db.Parameter<string> | db.SQLFragment;
       /**
-       * **document.origin**
-       * - `bytea` in database
-       * - `NOT NULL`, no default
-       */
-      origin:
-        | (db.ByteArrayString | Buffer)
-        | db.Parameter<db.ByteArrayString | Buffer>
-        | db.SQLFragment;
+      * **document.origin**
+      * - `bytea` in database
+      * - `NOT NULL`, no default
+      */
+      origin: (db.ByteArrayString | Buffer) | db.Parameter<(db.ByteArrayString | Buffer)> | db.SQLFragment;
       /**
-       * **document.latest_update_time**
-       * - `timestamp` in database
-       * - `NOT NULL`, no default
-       */
-      latest_update_time:
-        | (db.TimestampString | Date)
-        | db.Parameter<db.TimestampString | Date>
-        | db.SQLFragment;
+      * **document.latest_update_time**
+      * - `timestamp` in database
+      * - `NOT NULL`, no default
+      */
+      latest_update_time: (db.TimestampString | Date) | db.Parameter<(db.TimestampString | Date)> | db.SQLFragment;
       /**
-       * **document.creator_id**
-       * - `uuid` in database
-       * - `NOT NULL`, no default
-       */
+      * **document.creator_id**
+      * - `uuid` in database
+      * - `NOT NULL`, no default
+      */
       creator_id: string | db.Parameter<string> | db.SQLFragment;
+      /**
+      * **document.name**
+      * - `text` in database
+      * - `NOT NULL`, default: `''::text`
+      */
+      name?: string | db.Parameter<string> | db.DefaultType | db.SQLFragment;
     }
     export interface Updatable {
       /**
-       * **document.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
-      id?:
-        | string
-        | db.Parameter<string>
-        | db.DefaultType
-        | db.SQLFragment
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.DefaultType | db.SQLFragment
-          >;
+      * **document.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
+      id?: string | db.Parameter<string> | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.DefaultType | db.SQLFragment>;
       /**
-       * **document.value**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
-      value?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      * **document.value**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      value?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
       /**
-       * **document.web_rtc_key**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
-      web_rtc_key?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      * **document.web_rtc_key**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      web_rtc_key?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
       /**
-       * **document.origin**
-       * - `bytea` in database
-       * - `NOT NULL`, no default
-       */
-      origin?:
-        | (db.ByteArrayString | Buffer)
-        | db.Parameter<db.ByteArrayString | Buffer>
-        | db.SQLFragment
-        | db.SQLFragment<
-            any,
-            | (db.ByteArrayString | Buffer)
-            | db.Parameter<db.ByteArrayString | Buffer>
-            | db.SQLFragment
-          >;
+      * **document.origin**
+      * - `bytea` in database
+      * - `NOT NULL`, no default
+      */
+      origin?: (db.ByteArrayString | Buffer) | db.Parameter<(db.ByteArrayString | Buffer)> | db.SQLFragment | db.SQLFragment<any, (db.ByteArrayString | Buffer) | db.Parameter<(db.ByteArrayString | Buffer)> | db.SQLFragment>;
       /**
-       * **document.latest_update_time**
-       * - `timestamp` in database
-       * - `NOT NULL`, no default
-       */
-      latest_update_time?:
-        | (db.TimestampString | Date)
-        | db.Parameter<db.TimestampString | Date>
-        | db.SQLFragment
-        | db.SQLFragment<
-            any,
-            | (db.TimestampString | Date)
-            | db.Parameter<db.TimestampString | Date>
-            | db.SQLFragment
-          >;
+      * **document.latest_update_time**
+      * - `timestamp` in database
+      * - `NOT NULL`, no default
+      */
+      latest_update_time?: (db.TimestampString | Date) | db.Parameter<(db.TimestampString | Date)> | db.SQLFragment | db.SQLFragment<any, (db.TimestampString | Date) | db.Parameter<(db.TimestampString | Date)> | db.SQLFragment>;
       /**
-       * **document.creator_id**
-       * - `uuid` in database
-       * - `NOT NULL`, no default
-       */
-      creator_id?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      * **document.creator_id**
+      * - `uuid` in database
+      * - `NOT NULL`, no default
+      */
+      creator_id?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      /**
+      * **document.name**
+      * - `text` in database
+      * - `NOT NULL`, default: `''::text`
+      */
+      name?: string | db.Parameter<string> | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.DefaultType | db.SQLFragment>;
     }
-    export type UniqueIndex = "document_pkey";
+    export type UniqueIndex = 'document_pkey';
     export type Column = keyof Selectable;
-    export type OnlyCols<T extends readonly Column[]> = Pick<
-      Selectable,
-      T[number]
-    >;
-    export type SQLExpression =
-      | db.GenericSQLExpression
-      | db.ColumnNames<Updatable | (keyof Updatable)[]>
-      | db.ColumnValues<Updatable>
-      | Table
-      | Whereable
-      | Column;
+    export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
+    export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;
     export type SQL = SQLExpression | SQLExpression[];
   }
 
@@ -336,227 +259,141 @@ declare module "zapatos/schema" {
    * - Table in database
    */
   export namespace document_updates_queue {
-    export type Table = "document_updates_queue";
+    export type Table = 'document_updates_queue';
     export interface Selectable {
       /**
-       * **document_updates_queue.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
+      * **document_updates_queue.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
       id: string;
       /**
-       * **document_updates_queue.document_id**
-       * - `uuid` in database
-       * - `NOT NULL`, no default
-       */
+      * **document_updates_queue.document_id**
+      * - `uuid` in database
+      * - `NOT NULL`, no default
+      */
       document_id: string;
       /**
-       * **document_updates_queue.document_update**
-       * - `bytea` in database
-       * - `NOT NULL`, no default
-       */
+      * **document_updates_queue.document_update**
+      * - `bytea` in database
+      * - `NOT NULL`, no default
+      */
       document_update: Buffer;
       /**
-       * **document_updates_queue.created_at**
-       * - `timestamp` in database
-       * - `NOT NULL`, default: `now()`
-       */
+      * **document_updates_queue.created_at**
+      * - `timestamp` in database
+      * - `NOT NULL`, default: `now()`
+      */
       created_at: Date;
     }
     export interface JSONSelectable {
       /**
-       * **document_updates_queue.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
+      * **document_updates_queue.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
       id: string;
       /**
-       * **document_updates_queue.document_id**
-       * - `uuid` in database
-       * - `NOT NULL`, no default
-       */
+      * **document_updates_queue.document_id**
+      * - `uuid` in database
+      * - `NOT NULL`, no default
+      */
       document_id: string;
       /**
-       * **document_updates_queue.document_update**
-       * - `bytea` in database
-       * - `NOT NULL`, no default
-       */
+      * **document_updates_queue.document_update**
+      * - `bytea` in database
+      * - `NOT NULL`, no default
+      */
       document_update: db.ByteArrayString;
       /**
-       * **document_updates_queue.created_at**
-       * - `timestamp` in database
-       * - `NOT NULL`, default: `now()`
-       */
+      * **document_updates_queue.created_at**
+      * - `timestamp` in database
+      * - `NOT NULL`, default: `now()`
+      */
       created_at: db.TimestampString;
     }
     export interface Whereable {
       /**
-       * **document_updates_queue.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
-      id?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
-          >;
+      * **document_updates_queue.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
+      id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
       /**
-       * **document_updates_queue.document_id**
-       * - `uuid` in database
-       * - `NOT NULL`, no default
-       */
-      document_id?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
-          >;
+      * **document_updates_queue.document_id**
+      * - `uuid` in database
+      * - `NOT NULL`, no default
+      */
+      document_id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
       /**
-       * **document_updates_queue.document_update**
-       * - `bytea` in database
-       * - `NOT NULL`, no default
-       */
-      document_update?:
-        | (db.ByteArrayString | Buffer)
-        | db.Parameter<db.ByteArrayString | Buffer>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            | (db.ByteArrayString | Buffer)
-            | db.Parameter<db.ByteArrayString | Buffer>
-            | db.SQLFragment
-            | db.ParentColumn
-          >;
+      * **document_updates_queue.document_update**
+      * - `bytea` in database
+      * - `NOT NULL`, no default
+      */
+      document_update?: (db.ByteArrayString | Buffer) | db.Parameter<(db.ByteArrayString | Buffer)> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, (db.ByteArrayString | Buffer) | db.Parameter<(db.ByteArrayString | Buffer)> | db.SQLFragment | db.ParentColumn>;
       /**
-       * **document_updates_queue.created_at**
-       * - `timestamp` in database
-       * - `NOT NULL`, default: `now()`
-       */
-      created_at?:
-        | (db.TimestampString | Date)
-        | db.Parameter<db.TimestampString | Date>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            | (db.TimestampString | Date)
-            | db.Parameter<db.TimestampString | Date>
-            | db.SQLFragment
-            | db.ParentColumn
-          >;
+      * **document_updates_queue.created_at**
+      * - `timestamp` in database
+      * - `NOT NULL`, default: `now()`
+      */
+      created_at?: (db.TimestampString | Date) | db.Parameter<(db.TimestampString | Date)> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, (db.TimestampString | Date) | db.Parameter<(db.TimestampString | Date)> | db.SQLFragment | db.ParentColumn>;
     }
     export interface Insertable {
       /**
-       * **document_updates_queue.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
+      * **document_updates_queue.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
       id?: string | db.Parameter<string> | db.DefaultType | db.SQLFragment;
       /**
-       * **document_updates_queue.document_id**
-       * - `uuid` in database
-       * - `NOT NULL`, no default
-       */
+      * **document_updates_queue.document_id**
+      * - `uuid` in database
+      * - `NOT NULL`, no default
+      */
       document_id: string | db.Parameter<string> | db.SQLFragment;
       /**
-       * **document_updates_queue.document_update**
-       * - `bytea` in database
-       * - `NOT NULL`, no default
-       */
-      document_update:
-        | (db.ByteArrayString | Buffer)
-        | db.Parameter<db.ByteArrayString | Buffer>
-        | db.SQLFragment;
+      * **document_updates_queue.document_update**
+      * - `bytea` in database
+      * - `NOT NULL`, no default
+      */
+      document_update: (db.ByteArrayString | Buffer) | db.Parameter<(db.ByteArrayString | Buffer)> | db.SQLFragment;
       /**
-       * **document_updates_queue.created_at**
-       * - `timestamp` in database
-       * - `NOT NULL`, default: `now()`
-       */
-      created_at?:
-        | (db.TimestampString | Date)
-        | db.Parameter<db.TimestampString | Date>
-        | db.DefaultType
-        | db.SQLFragment;
+      * **document_updates_queue.created_at**
+      * - `timestamp` in database
+      * - `NOT NULL`, default: `now()`
+      */
+      created_at?: (db.TimestampString | Date) | db.Parameter<(db.TimestampString | Date)> | db.DefaultType | db.SQLFragment;
     }
     export interface Updatable {
       /**
-       * **document_updates_queue.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
-      id?:
-        | string
-        | db.Parameter<string>
-        | db.DefaultType
-        | db.SQLFragment
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.DefaultType | db.SQLFragment
-          >;
+      * **document_updates_queue.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
+      id?: string | db.Parameter<string> | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.DefaultType | db.SQLFragment>;
       /**
-       * **document_updates_queue.document_id**
-       * - `uuid` in database
-       * - `NOT NULL`, no default
-       */
-      document_id?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      * **document_updates_queue.document_id**
+      * - `uuid` in database
+      * - `NOT NULL`, no default
+      */
+      document_id?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
       /**
-       * **document_updates_queue.document_update**
-       * - `bytea` in database
-       * - `NOT NULL`, no default
-       */
-      document_update?:
-        | (db.ByteArrayString | Buffer)
-        | db.Parameter<db.ByteArrayString | Buffer>
-        | db.SQLFragment
-        | db.SQLFragment<
-            any,
-            | (db.ByteArrayString | Buffer)
-            | db.Parameter<db.ByteArrayString | Buffer>
-            | db.SQLFragment
-          >;
+      * **document_updates_queue.document_update**
+      * - `bytea` in database
+      * - `NOT NULL`, no default
+      */
+      document_update?: (db.ByteArrayString | Buffer) | db.Parameter<(db.ByteArrayString | Buffer)> | db.SQLFragment | db.SQLFragment<any, (db.ByteArrayString | Buffer) | db.Parameter<(db.ByteArrayString | Buffer)> | db.SQLFragment>;
       /**
-       * **document_updates_queue.created_at**
-       * - `timestamp` in database
-       * - `NOT NULL`, default: `now()`
-       */
-      created_at?:
-        | (db.TimestampString | Date)
-        | db.Parameter<db.TimestampString | Date>
-        | db.DefaultType
-        | db.SQLFragment
-        | db.SQLFragment<
-            any,
-            | (db.TimestampString | Date)
-            | db.Parameter<db.TimestampString | Date>
-            | db.DefaultType
-            | db.SQLFragment
-          >;
+      * **document_updates_queue.created_at**
+      * - `timestamp` in database
+      * - `NOT NULL`, default: `now()`
+      */
+      created_at?: (db.TimestampString | Date) | db.Parameter<(db.TimestampString | Date)> | db.DefaultType | db.SQLFragment | db.SQLFragment<any, (db.TimestampString | Date) | db.Parameter<(db.TimestampString | Date)> | db.DefaultType | db.SQLFragment>;
     }
-    export type UniqueIndex = "document_updates_queue_pkey";
+    export type UniqueIndex = 'document_updates_queue_pkey';
     export type Column = keyof Selectable;
-    export type OnlyCols<T extends readonly Column[]> = Pick<
-      Selectable,
-      T[number]
-    >;
-    export type SQLExpression =
-      | db.GenericSQLExpression
-      | db.ColumnNames<Updatable | (keyof Updatable)[]>
-      | db.ColumnValues<Updatable>
-      | Table
-      | Whereable
-      | Column;
+    export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
+    export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;
     export type SQL = SQLExpression | SQLExpression[];
   }
 
@@ -565,72 +402,51 @@ declare module "zapatos/schema" {
    * - Table in database
    */
   export namespace schema_migrations {
-    export type Table = "schema_migrations";
+    export type Table = 'schema_migrations';
     export interface Selectable {
       /**
-       * **schema_migrations.version**
-       * - `varchar` in database
-       * - `NOT NULL`, no default
-       */
+      * **schema_migrations.version**
+      * - `varchar` in database
+      * - `NOT NULL`, no default
+      */
       version: string;
     }
     export interface JSONSelectable {
       /**
-       * **schema_migrations.version**
-       * - `varchar` in database
-       * - `NOT NULL`, no default
-       */
+      * **schema_migrations.version**
+      * - `varchar` in database
+      * - `NOT NULL`, no default
+      */
       version: string;
     }
     export interface Whereable {
       /**
-       * **schema_migrations.version**
-       * - `varchar` in database
-       * - `NOT NULL`, no default
-       */
-      version?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
-          >;
+      * **schema_migrations.version**
+      * - `varchar` in database
+      * - `NOT NULL`, no default
+      */
+      version?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
     }
     export interface Insertable {
       /**
-       * **schema_migrations.version**
-       * - `varchar` in database
-       * - `NOT NULL`, no default
-       */
+      * **schema_migrations.version**
+      * - `varchar` in database
+      * - `NOT NULL`, no default
+      */
       version: string | db.Parameter<string> | db.SQLFragment;
     }
     export interface Updatable {
       /**
-       * **schema_migrations.version**
-       * - `varchar` in database
-       * - `NOT NULL`, no default
-       */
-      version?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      * **schema_migrations.version**
+      * - `varchar` in database
+      * - `NOT NULL`, no default
+      */
+      version?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
     }
-    export type UniqueIndex = "schema_migrations_pkey";
+    export type UniqueIndex = 'schema_migrations_pkey';
     export type Column = keyof Selectable;
-    export type OnlyCols<T extends readonly Column[]> = Pick<
-      Selectable,
-      T[number]
-    >;
-    export type SQLExpression =
-      | db.GenericSQLExpression
-      | db.ColumnNames<Updatable | (keyof Updatable)[]>
-      | db.ColumnValues<Updatable>
-      | Table
-      | Whereable
-      | Column;
+    export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
+    export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;
     export type SQL = SQLExpression | SQLExpression[];
   }
 
@@ -639,190 +455,111 @@ declare module "zapatos/schema" {
    * - Table in database
    */
   export namespace user_document {
-    export type Table = "user_document";
+    export type Table = 'user_document';
     export interface Selectable {
       /**
-       * **user_document.document_id**
-       * - `uuid` in database
-       * - Nullable, no default
-       */
+      * **user_document.document_id**
+      * - `uuid` in database
+      * - Nullable, no default
+      */
       document_id: string | null;
       /**
-       * **user_document.user_id**
-       * - `uuid` in database
-       * - Nullable, no default
-       */
+      * **user_document.user_id**
+      * - `uuid` in database
+      * - Nullable, no default
+      */
       user_id: string | null;
       /**
-       * **user_document.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
+      * **user_document.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
       id: string;
     }
     export interface JSONSelectable {
       /**
-       * **user_document.document_id**
-       * - `uuid` in database
-       * - Nullable, no default
-       */
+      * **user_document.document_id**
+      * - `uuid` in database
+      * - Nullable, no default
+      */
       document_id: string | null;
       /**
-       * **user_document.user_id**
-       * - `uuid` in database
-       * - Nullable, no default
-       */
+      * **user_document.user_id**
+      * - `uuid` in database
+      * - Nullable, no default
+      */
       user_id: string | null;
       /**
-       * **user_document.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
+      * **user_document.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
       id: string;
     }
     export interface Whereable {
       /**
-       * **user_document.document_id**
-       * - `uuid` in database
-       * - Nullable, no default
-       */
-      document_id?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
-          >;
+      * **user_document.document_id**
+      * - `uuid` in database
+      * - Nullable, no default
+      */
+      document_id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
       /**
-       * **user_document.user_id**
-       * - `uuid` in database
-       * - Nullable, no default
-       */
-      user_id?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
-          >;
+      * **user_document.user_id**
+      * - `uuid` in database
+      * - Nullable, no default
+      */
+      user_id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
       /**
-       * **user_document.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
-      id?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
-          >;
+      * **user_document.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
+      id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
     }
     export interface Insertable {
       /**
-       * **user_document.document_id**
-       * - `uuid` in database
-       * - Nullable, no default
-       */
-      document_id?:
-        | string
-        | db.Parameter<string>
-        | null
-        | db.DefaultType
-        | db.SQLFragment;
+      * **user_document.document_id**
+      * - `uuid` in database
+      * - Nullable, no default
+      */
+      document_id?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment;
       /**
-       * **user_document.user_id**
-       * - `uuid` in database
-       * - Nullable, no default
-       */
-      user_id?:
-        | string
-        | db.Parameter<string>
-        | null
-        | db.DefaultType
-        | db.SQLFragment;
+      * **user_document.user_id**
+      * - `uuid` in database
+      * - Nullable, no default
+      */
+      user_id?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment;
       /**
-       * **user_document.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
+      * **user_document.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
       id?: string | db.Parameter<string> | db.DefaultType | db.SQLFragment;
     }
     export interface Updatable {
       /**
-       * **user_document.document_id**
-       * - `uuid` in database
-       * - Nullable, no default
-       */
-      document_id?:
-        | string
-        | db.Parameter<string>
-        | null
-        | db.DefaultType
-        | db.SQLFragment
-        | db.SQLFragment<
-            any,
-            | string
-            | db.Parameter<string>
-            | null
-            | db.DefaultType
-            | db.SQLFragment
-          >;
+      * **user_document.document_id**
+      * - `uuid` in database
+      * - Nullable, no default
+      */
+      document_id?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment>;
       /**
-       * **user_document.user_id**
-       * - `uuid` in database
-       * - Nullable, no default
-       */
-      user_id?:
-        | string
-        | db.Parameter<string>
-        | null
-        | db.DefaultType
-        | db.SQLFragment
-        | db.SQLFragment<
-            any,
-            | string
-            | db.Parameter<string>
-            | null
-            | db.DefaultType
-            | db.SQLFragment
-          >;
+      * **user_document.user_id**
+      * - `uuid` in database
+      * - Nullable, no default
+      */
+      user_id?: string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | null | db.DefaultType | db.SQLFragment>;
       /**
-       * **user_document.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
-      id?:
-        | string
-        | db.Parameter<string>
-        | db.DefaultType
-        | db.SQLFragment
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.DefaultType | db.SQLFragment
-          >;
+      * **user_document.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
+      id?: string | db.Parameter<string> | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.DefaultType | db.SQLFragment>;
     }
-    export type UniqueIndex =
-      | "user_document_document_id_user_id_key"
-      | "user_document_pkey";
+    export type UniqueIndex = 'user_document_document_id_user_id_key' | 'user_document_pkey';
     export type Column = keyof Selectable;
-    export type OnlyCols<T extends readonly Column[]> = Pick<
-      Selectable,
-      T[number]
-    >;
-    export type SQLExpression =
-      | db.GenericSQLExpression
-      | db.ColumnNames<Updatable | (keyof Updatable)[]>
-      | db.ColumnValues<Updatable>
-      | Table
-      | Whereable
-      | Column;
+    export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
+    export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;
     export type SQL = SQLExpression | SQLExpression[];
   }
 
@@ -831,238 +568,130 @@ declare module "zapatos/schema" {
    * - Table in database
    */
   export namespace users {
-    export type Table = "users";
+    export type Table = 'users';
     export interface Selectable {
       /**
-       * **users.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
+      * **users.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
       id: string;
       /**
-       * **users.name**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
+      * **users.name**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
       name: string;
       /**
-       * **users.password**
-       * - `text` in database
-       * - `NOT NULL`, default: `''::text`
-       */
+      * **users.password**
+      * - `text` in database
+      * - `NOT NULL`, default: `''::text`
+      */
       password: string;
     }
     export interface JSONSelectable {
       /**
-       * **users.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
+      * **users.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
       id: string;
       /**
-       * **users.name**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
+      * **users.name**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
       name: string;
       /**
-       * **users.password**
-       * - `text` in database
-       * - `NOT NULL`, default: `''::text`
-       */
+      * **users.password**
+      * - `text` in database
+      * - `NOT NULL`, default: `''::text`
+      */
       password: string;
     }
     export interface Whereable {
       /**
-       * **users.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
-      id?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
-          >;
+      * **users.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
+      id?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
       /**
-       * **users.name**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
-      name?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
-          >;
+      * **users.name**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      name?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
       /**
-       * **users.password**
-       * - `text` in database
-       * - `NOT NULL`, default: `''::text`
-       */
-      password?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.ParentColumn
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.SQLFragment | db.ParentColumn
-          >;
+      * **users.password**
+      * - `text` in database
+      * - `NOT NULL`, default: `''::text`
+      */
+      password?: string | db.Parameter<string> | db.SQLFragment | db.ParentColumn | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment | db.ParentColumn>;
     }
     export interface Insertable {
       /**
-       * **users.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
+      * **users.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
       id?: string | db.Parameter<string> | db.DefaultType | db.SQLFragment;
       /**
-       * **users.name**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
+      * **users.name**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
       name: string | db.Parameter<string> | db.SQLFragment;
       /**
-       * **users.password**
-       * - `text` in database
-       * - `NOT NULL`, default: `''::text`
-       */
-      password?:
-        | string
-        | db.Parameter<string>
-        | db.DefaultType
-        | db.SQLFragment;
+      * **users.password**
+      * - `text` in database
+      * - `NOT NULL`, default: `''::text`
+      */
+      password?: string | db.Parameter<string> | db.DefaultType | db.SQLFragment;
     }
     export interface Updatable {
       /**
-       * **users.id**
-       * - `uuid` in database
-       * - `NOT NULL`, default: `uuid_generate_v4()`
-       */
-      id?:
-        | string
-        | db.Parameter<string>
-        | db.DefaultType
-        | db.SQLFragment
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.DefaultType | db.SQLFragment
-          >;
+      * **users.id**
+      * - `uuid` in database
+      * - `NOT NULL`, default: `uuid_generate_v4()`
+      */
+      id?: string | db.Parameter<string> | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.DefaultType | db.SQLFragment>;
       /**
-       * **users.name**
-       * - `text` in database
-       * - `NOT NULL`, no default
-       */
-      name?:
-        | string
-        | db.Parameter<string>
-        | db.SQLFragment
-        | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
+      * **users.name**
+      * - `text` in database
+      * - `NOT NULL`, no default
+      */
+      name?: string | db.Parameter<string> | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.SQLFragment>;
       /**
-       * **users.password**
-       * - `text` in database
-       * - `NOT NULL`, default: `''::text`
-       */
-      password?:
-        | string
-        | db.Parameter<string>
-        | db.DefaultType
-        | db.SQLFragment
-        | db.SQLFragment<
-            any,
-            string | db.Parameter<string> | db.DefaultType | db.SQLFragment
-          >;
+      * **users.password**
+      * - `text` in database
+      * - `NOT NULL`, default: `''::text`
+      */
+      password?: string | db.Parameter<string> | db.DefaultType | db.SQLFragment | db.SQLFragment<any, string | db.Parameter<string> | db.DefaultType | db.SQLFragment>;
     }
-    export type UniqueIndex = "unique_user_name" | "users_pkey";
+    export type UniqueIndex = 'unique_user_name' | 'users_pkey';
     export type Column = keyof Selectable;
-    export type OnlyCols<T extends readonly Column[]> = Pick<
-      Selectable,
-      T[number]
-    >;
-    export type SQLExpression =
-      | db.GenericSQLExpression
-      | db.ColumnNames<Updatable | (keyof Updatable)[]>
-      | db.ColumnValues<Updatable>
-      | Table
-      | Whereable
-      | Column;
+    export type OnlyCols<T extends readonly Column[]> = Pick<Selectable, T[number]>;
+    export type SQLExpression = db.GenericSQLExpression | db.ColumnNames<Updatable | (keyof Updatable)[]> | db.ColumnValues<Updatable> | Table | Whereable | Column;
     export type SQL = SQLExpression | SQLExpression[];
   }
 
   /* === cross-table types === */
 
-  export type Table =
-    | document.Table
-    | document_updates_queue.Table
-    | schema_migrations.Table
-    | user_document.Table
-    | users.Table;
-  export type Selectable =
-    | document.Selectable
-    | document_updates_queue.Selectable
-    | schema_migrations.Selectable
-    | user_document.Selectable
-    | users.Selectable;
-  export type JSONSelectable =
-    | document.JSONSelectable
-    | document_updates_queue.JSONSelectable
-    | schema_migrations.JSONSelectable
-    | user_document.JSONSelectable
-    | users.JSONSelectable;
-  export type Whereable =
-    | document.Whereable
-    | document_updates_queue.Whereable
-    | schema_migrations.Whereable
-    | user_document.Whereable
-    | users.Whereable;
-  export type Insertable =
-    | document.Insertable
-    | document_updates_queue.Insertable
-    | schema_migrations.Insertable
-    | user_document.Insertable
-    | users.Insertable;
-  export type Updatable =
-    | document.Updatable
-    | document_updates_queue.Updatable
-    | schema_migrations.Updatable
-    | user_document.Updatable
-    | users.Updatable;
-  export type UniqueIndex =
-    | document.UniqueIndex
-    | document_updates_queue.UniqueIndex
-    | schema_migrations.UniqueIndex
-    | user_document.UniqueIndex
-    | users.UniqueIndex;
-  export type Column =
-    | document.Column
-    | document_updates_queue.Column
-    | schema_migrations.Column
-    | user_document.Column
-    | users.Column;
-  export type AllBaseTables = [
-    document.Table,
-    document_updates_queue.Table,
-    schema_migrations.Table,
-    user_document.Table,
-    users.Table
-  ];
+  export type Table = document.Table | document_updates_queue.Table | schema_migrations.Table | user_document.Table | users.Table;
+  export type Selectable = document.Selectable | document_updates_queue.Selectable | schema_migrations.Selectable | user_document.Selectable | users.Selectable;
+  export type JSONSelectable = document.JSONSelectable | document_updates_queue.JSONSelectable | schema_migrations.JSONSelectable | user_document.JSONSelectable | users.JSONSelectable;
+  export type Whereable = document.Whereable | document_updates_queue.Whereable | schema_migrations.Whereable | user_document.Whereable | users.Whereable;
+  export type Insertable = document.Insertable | document_updates_queue.Insertable | schema_migrations.Insertable | user_document.Insertable | users.Insertable;
+  export type Updatable = document.Updatable | document_updates_queue.Updatable | schema_migrations.Updatable | user_document.Updatable | users.Updatable;
+  export type UniqueIndex = document.UniqueIndex | document_updates_queue.UniqueIndex | schema_migrations.UniqueIndex | user_document.UniqueIndex | users.UniqueIndex;
+  export type Column = document.Column | document_updates_queue.Column | schema_migrations.Column | user_document.Column | users.Column;
+  export type AllBaseTables = [document.Table, document_updates_queue.Table, schema_migrations.Table, user_document.Table, users.Table];
   export type AllForeignTables = [];
   export type AllViews = [];
   export type AllMaterializedViews = [];
-  export type AllTablesAndViews = [
-    document.Table,
-    document_updates_queue.Table,
-    schema_migrations.Table,
-    user_document.Table,
-    users.Table
-  ];
+  export type AllTablesAndViews = [document.Table, document_updates_queue.Table, schema_migrations.Table, user_document.Table, users.Table];
+
 
   export type SelectableForTable<T extends Table> = {
     document: document.Selectable;
@@ -1127,4 +756,5 @@ declare module "zapatos/schema" {
     user_document: user_document.SQL;
     users: users.SQL;
   }[T];
+
 }

--- a/terraform/nginx/default.conf.template
+++ b/terraform/nginx/default.conf.template
@@ -2,15 +2,6 @@
 server { 
   listen       ${PORT};
   
-
-  location = / {
-    proxy_pass  ${STATIC_URL}/index.html;
-    proxy_redirect off;
-  }
-  location = /login {
-    proxy_pass  ${STATIC_URL}/login.html;
-    proxy_redirect off;
-  }
   location / {
      proxy_pass  ${STATIC_URL}/;
      proxy_redirect off;


### PR DESCRIPTION
This PR contains a migration to add a name column to the document table, and has the beginning edits of the http requests for retaining documents with their corresponding names. Instead of choosing a document with a key, you choose by the name given.